### PR TITLE
np.copy not needed when accessing a subset of a chunk

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1631,7 +1631,7 @@ class Array(object):
                 if self._chunk_cache is not None:
                     self._chunk_cache[ckey] = np.copy(chunk)
             else:
-                chunk = np.copy(cdata)
+                chunk = cdata
 
             # select data from chunk
             if fields:


### PR DESCRIPTION
[Description of PR]

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Unit tests and doctests pass locally under Python 3.6 (e.g., run ``tox -e py36`` or 
  ``pytest -v --doctest-modules zarr``)
* [ ] Unit tests pass locally under Python 2.7 (e.g., run ``tox -e py27`` or
  ``pytest -v zarr``)
* [ ] PEP8 checks pass (e.g., run ``tox -e py36`` or ``flake8 --max-line-length=100 zarr``)
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Doctests in tutorial pass (e.g., run ``tox -e py36`` or ``python -m doctest -o NORMALIZE_WHITESPACE -o ELLIPSIS docs/tutorial.rst``)
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
